### PR TITLE
background-processes 초안 번역

### DIFF
--- a/src/docs/development/packages-and-plugins/background-processes.md
+++ b/src/docs/development/packages-and-plugins/background-processes.md
@@ -1,10 +1,10 @@
 ---
 title: 백그라운드 프로세스
-description: Flutter에서 백그라운드 프로세스 구현에 대한 추가 정보의 위치  
+description: Flutter에서 백그라운드 프로세스를 구현하는데 필요한 추가 정보
 ---
 
 백그라운드에서 Dart 코드를 실행하고 싶었던 적이 있습니까? 앱이 활성화되어 있지 않은 상태일지라도 말이죠. 어쩌면 여려분은 시간을 주시하거나 또는 카메라의 움직임을 캐치하는 프로세스를 만들고 싶었을 수도 있습니다. Flutter에서는 백그라운드에서 Dart 코드를 실행할 수 있습니다.
 
-이 기능의 메커니즘은 격리를 설정하는 것입니다. _Isolates_ 는 Dart의 멀티스레딩을 위한 모델인데, 메인 프로그램과 메모리를 공유하지 않는다는 점에서 통속적인 스레드의 격리와는 다릅니다. 콜백과 콜백 디스패처를 이용해서 백그라운드 실행을 위한 격리를 설정합니다. 
+이 기능의 메커니즘은 isolate를 설정하는 것입니다. _Isolates_ 는 Dart의 멀티스레딩을 위한 모델인데, 메인 프로그램과 메모리를 공유하지 않는다는 점에서 통속적인 스레드의 isolate과는 다릅니다. 콜백과 콜백 디스패처를 이용해서 백그라운드 실행을 위한 isolate를 설정합니다. 
 
-자세한 정보 및 Dart 코드의 백그라운드 실행을 사용하는 지오펜싱 예제는 미디움(Medium)의 Flutter Publication에 있는 [Dart에서 Flutter 플러그인과 지오펜싱을 이용한 백그라운드 실행]({{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124) 글을 보시면 됩니다. 글을 끝부분에는 예제 코드에 대한 링크와 Dart, iOS, Android를 위한 관련 문서가 나와있습니다. 
+더 자세한 정보 및 Dart의 백그라운드 프로세스가 적용된 Geofencing 예제는 Medium의 Flutter Publication에 있는 [Dart에서 Flutter 플러그인과 Geofencing을 이용한 백그라운드 실행]({{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124) 을 참고하시기 바랍니다. 글의 끝부분에는 예제 코드에 대한 링크와 Dart, iOS, Android를 위한 관련 문서가 나와있습니다. 

--- a/src/docs/development/packages-and-plugins/background-processes.md
+++ b/src/docs/development/packages-and-plugins/background-processes.md
@@ -1,24 +1,10 @@
 ---
-title: Background processes
-description: Where to find more information on implementing background processes in Flutter.
+title: 백그라운드 프로세스
+description: Flutter에서 백그라운드 프로세스 구현에 대한 추가 정보의 위치  
 ---
 
-Have you ever wanted to execute Dart code in the background—even if
-your app wasn’t the currently active app? Perhaps you wanted to implement
-a process that watches the time, or that catches camera movement.
-In Flutter, you can execute Dart code in the background.
+백그라운드에서 Dart 코드를 실행하고 싶었던 적이 있습니까? 앱이 활성화되어 있지 않은 상태일지라도 말이죠. 어쩌면 여려분은 시간을 주시하거나 또는 카메라의 움직임을 캐치하는 프로세스를 만들고 싶었을 수도 있습니다. Flutter에서는 백그라운드에서 Dart 코드를 실행할 수 있습니다.
 
-The mechanism for this feature involves setting up an isolate. _Isolates_
-are Dart’s model for multithreading, though an isolate differs from a
-conventional thread in that it doesn’t share memory with the main program.
-You’ll set up your isolate for background execution using callbacks and
-a callback dispatcher.
+이 기능의 메커니즘은 격리를 설정하는 것입니다. _Isolates_ 는 Dart의 멀티스레딩을 위한 모델인데, 메인 프로그램과 메모리를 공유하지 않는다는 점에서 통속적인 스레드의 격리와는 다릅니다. 콜백과 콜백 디스패처를 이용해서 백그라운드 실행을 위한 격리를 설정합니다. 
 
-For more information and a geofencing example that uses background
-execution of Dart code, see [Executing Dart in the Background with
-Flutter Plugins and
-Geofencing]({{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124),
-an article in the Flutter Publication on Medium. At the end of this article,
-you’ll find links to example code, and relevant documentation for Dart,
-iOS, and Android.
-
+자세한 정보 및 Dart 코드의 백그라운드 실행을 사용하는 지오펜싱 예제는 미디움(Medium)의 Flutter Publication에 있는 [Dart에서 Flutter 플러그인과 지오펜싱을 이용한 백그라운드 실행]({{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124) 글을 보시면 됩니다. 글을 끝부분에는 예제 코드에 대한 링크와 Dart, iOS, Android를 위한 관련 문서가 나와있습니다. 


### PR DESCRIPTION
background-processes 문서의 초안번역입니다.

- 문서에 Thread에 대한 isolate 개념이 나오는데 이 부분은 격리로 번역했습니다
   - Flutter에서 Isolate에 대한 설명은 isolate 로 그대로 번역했습니다 
- Dart 는 다트가 아닌 Dart로 번역했습니다